### PR TITLE
chat: typo and grammar fixes

### DIFF
--- a/src/support/chat.rst
+++ b/src/support/chat.rst
@@ -4,12 +4,12 @@ Chat
 For daily communication in ongoing projects we also offer the opportunity to chat with us.
 We decided to base our system upon the Matrix-protocol by hosting our own homeserver for every of our users. We do also provide a self-hosted and pre-configurated version of Element to allow easy access. However, alternative clients are allowed and welcomed to use.
 
-We usually create a project specific Matrix channel and invite all needed persons to join. You may participate using the Matrix ID provided by us, or your currently existing ID at any other homeserver of your choice. In this case: Just let us know how we can reach you.
+We usually create a project-specific Matrix channel and invite all needed persons to join. You may participate using the Matrix ID provided by us, or your currently existing ID at any other homeserver of your choice. In this case: Just let us know how we can reach you.
 
-If you want to use our Matrix setup, can find our pre-configured Element at `chat.flyingcircus.io
+If you want to use our Matrix setup, our pre-configured Element is available at `chat.flyingcircus.io
 <https://chat.flyingcircus.io>`_.
 
-If you want to use your own client, please find needed information below:
+If you want to use your own client, please find the needed information below:
 
 +------------------+------------------------------------+
 | Homeserver       |  customermatrix.flyingcircus.io    |


### PR DESCRIPTION
The changes are rather self-evident. A few linking words (or characters) where missing, I took the liberty of rephrasing one sentence instead of just inserting the missing words as that would've caused unnecessary repetition of words in close proximity.