### PR TITLE
Use the correct domain name in jump host configuration snippet

### DIFF
--- a/src/infrastructure/networking/connecting.md
+++ b/src/infrastructure/networking/connecting.md
@@ -104,7 +104,7 @@ Host *.fcio.net
     ProxyCommand ssh flyingcircus-jump-host -W %h:%p
 
 Host flyingcircus-jump-host
-    HostName <VMNAME>.fe.rzob.ipv4.fcio.net
+    HostName <VMNAME>.fe.rzob.ipv4.gocept.net
     User <USERNAME>
     ProxyCommand none
 ```


### PR DESCRIPTION
The documentation for SSH jump hosts uses the IPv4-only DNS alias of the jump host machine, however the IPv4-only aliases are only set under `gocept.net` and not mirrored under `fcio.net`. Hence, the `HostName` for the jump host should use the `gocept.net` DNS name.