### PR TITLE
reference data-centers: mention RZHAL

### DIFF
--- a/src/reference/hardware/data-centers.md
+++ b/src/reference/hardware/data-centers.md
@@ -4,9 +4,9 @@
 
 The following data centers are currently used by the Flying Circus:
 
-| Data center operator                   | Location            | Internal ID |
+| Data center operator                   | Location            | Internal IDs |
 | -------------------------------------- | ------------------- | ----------- |
 | [Kamp Netzwerkdienste GmbH]            | Oberhausen, Germany | RZOB        |
-| Flying Circus Internet Operations GmbH | Halle, Germany      | DEV, WHQ    |
+| Flying Circus Internet Operations GmbH | Halle, Germany      | RZHAL (includes DEV, WHQ)    |
 
 [kamp netzwerkdienste gmbh]: http://www.kamp.de/kamp-rechenzentrum.html


### PR DESCRIPTION
In some occasions, we mention the name *RZHAL* to our customers, e.g. for planned maintenace announcements on our statuspage. Now we at least mention this short code in our list of datacenters, while continuing to list the identifiers of the 2 sub components hosted in there.

PL-132112