### PR TITLE
Fix broken references to current platform

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -93,6 +93,9 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+# allow tel: links
+myst_url_schemes=["http", "https", "tel", "mailto"]
+
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/src/guide/platform_nixos/index.md
+++ b/src/guide/platform_nixos/index.md
@@ -6,7 +6,7 @@ Our second-generation platform is based upon [NixOS 15.09](http://nixos.org/).
 We are providing a subset of the features and components that
 are available on our first-generation Gentoo-based platform.
 
-It is outdated and replaced by current [NixOS platforms](/roles/current).
+It is outdated and replaced by a current {external+platform-current:ref}`NixOS platform <nixos-platform-index>`.
 Updates and changes are provided to assist migration to the new platform.
 
 NixOS provides new approaches for installing and managing software. Also,

--- a/src/guide/tutorial/index.md
+++ b/src/guide/tutorial/index.md
@@ -205,7 +205,7 @@ The benefit of managed components are:
 - regular upgrades and configuration optimization
 
 For details on available software, have a look at
-the [current NixOS platform documentation](/roles/current).
+the {external+platform-current:ref}`current NixOS platform documentation <nixos-platform-index>`.
 
 You can see and change the managed components/roles for your VMs by visiting the
 [My Flying Circus](https://my.flyingcircus.io) and selecting

--- a/src/infrastructure/networking/firewall.md
+++ b/src/infrastructure/networking/firewall.md
@@ -40,7 +40,7 @@ example:
 
 How to add custom firewall rules depends on the platform of your VM:
 
-- [NixOS 19.03 and newer](/roles/current/firewall.html)
+- NixOS 19.03 and newer each have their dedicated {external+platform-current:ref}`nixos-firewall` page.
 - {ref}`NixOS 15.09 <nixos-firewall>`
 
 % vim: set spell spelllang=en:


### PR DESCRIPTION
Links starting with a `/` are assumed to be internal references by default by MySt-parser. If no reference is found, the link is not made.

I replaced these links with proper intersphinx references to the corresponding fc-nixos docs. For the index page, a label had to be added in flyingcircusio/fc-nixos#924

tests made:
- [x] built the docs with updated objects.inv from flyingcircusio/fc-nixos#924, checked that references are rendered correctly

PL-132142