### PR TITLE
router/firewall: reopen port 80/443 as we need Let's Encrypt.

### DIFF
--- a/src/infrastructure/networking/firewall.md
+++ b/src/infrastructure/networking/firewall.md
@@ -22,6 +22,7 @@ can be opened by default. Machines inside the same project may access the
 Currently we allow public access for:
 
 - SSH (22) - to provide login access to VMs
+- HTTP/S (80, 443) - to allow using HTTP-based verification of Let's Encrypt certificates on the internal network and to present select services (IPv6 only) as needed
 - NTP (123) - to synchronize clocks with outside hosts
 - BGP (179, INPUT routers) to peer with uplink providers
 - Domain (53, INPUT on routers) to provide access to selected authoritative zones


### PR DESCRIPTION
Those ports were turned off during the router migration to NixOS because we thought they were only there for historical reasons when we used to present awstats on this port. Nowadays, we do leverage let's encrypt for internal names in many places and this breaks certificate generation/renewal.

VMs protect themselves on 80/443 anyway, so this is safe.

Re PL-132680

See 7d739931b532f13f3db2e8a9700b418d61993c1b in fc-nixos for the actual change.