### PR TITLE
Data protection reference: Document use of data-at-rest encryption

### DIFF
--- a/src/infrastructure/storage.md
+++ b/src/infrastructure/storage.md
@@ -3,6 +3,8 @@
 # Virtual Disks / Block Storage
 
 VM storage is provided by a Ceph cluster as virtual disks / block devices.
+The data in the cluster is transparently encrypted before being stored onto
+physical disks, see [](#data-at-rest-encryption) for details.
 
 Each virtual disk is visible in VMs as {file}`/dev/vda` and reflects an
 underlying Ceph [RBD volume][rbd volume].

--- a/src/reference/security/backup.md
+++ b/src/reference/security/backup.md
@@ -24,6 +24,9 @@ backup solution.
 
 S3 data is *not* backed up automatically.
 
+All backup storage data is transparently encrypted before being stored onto
+physical disks, see [](#data-at-rest-encryption) for details.
+
 ## Schedule
 
 Backups are run daily or hourly, depending on the chosen backup level.

--- a/src/reference/security/data-protection.md
+++ b/src/reference/security/data-protection.md
@@ -1,49 +1,46 @@
-.. last review: 2023-08-25
-.. review schedule: 1 year
-.. Customers need to be notified when substantial changes occur in this document!
+% last review: 2023-08-25
 
-.. _data-protection:
+% review schedule: 1 year
 
-Data protection measures
-========================
+% Customers need to be notified when substantial changes occur in this document!
+
+(data-protection)=
+
+# Data protection measures
 
 In addition to purely technical security measures we implement additional
 measures to provide a safe environment for your and your customers' data
 based on the following standards and regulations:
 
-.. image:: Zertlogo_Flying_Circus_bunt.png
-  :align: right
-  :width: 25%
-  :target: https://flyingcircus.io/iso-27001-en.pdf
+```{image} Zertlogo_Flying_Circus_bunt.png
+:align: right
+:target: https://flyingcircus.io/iso-27001-en.pdf
+:width: 25%
+```
 
+- [Certified](https://flyingcircus.io/iso-27001-en.pdf) Information Security Management System (ISMS) based on ISO/IEC 27001,
+- Germany's [federal data protection law (BDSG)](http://de.wikipedia.org/wiki/Bundesdatenschutzgesetz), and
+- the EU's [General Data Protection Regulation (GDPR)](https://de.wikipedia.org/wiki/Datenschutz-Grundverordnung).
 
-* `Certified <https://flyingcircus.io/iso-27001-en.pdf>`_ Information Security Management System (ISMS) based on ISO/IEC 27001,
-* Germany's `federal data protection law (BDSG) <http://de.wikipedia.org/wiki/Bundesdatenschutzgesetz>`_, and
-* the EU's `General Data Protection Regulation (GDPR) <https://de.wikipedia.org/wiki/Datenschutz-Grundverordnung>`_.
-
-Responsible bodies
-------------------
+## Responsible bodies
 
 **Information Security officers:**
 
-| Christian Zagrodnick (CISO)
-| cz@flyingcircus.io
+Christian Zagrodnick (CISO) \
+<mailto:cz@flyingcircus.io>
 
-| Christian Schmidt (ISO)
-| cs@flyingcircus.io
-
+Christian Schmidt (ISO) \
+<mailto:cs@flyingcircus.io>
 
 **Data protection officer:**
 
-| Prof. Dr. Andre Döring
-| Robin Data GmbH
-| Fritz-Haber-Straße 9 · 06217 Merseburg
-| https://www.robin-data.io · datenschutz@robin-data.io
-| `+49 3461 4798960 <tel:+4934614798960>`_
+Prof. Dr. Andre Döring \
+Robin Data GmbH \
+Fritz-Haber-Straße 9 · 06217 Merseburg \
+<https://www.robin-data.io> · <mailto:datenschutz@robin-data.io> \
+[+49 3461 4798960](tel:+4934614798960)
 
-
-General
--------
+## General
 
 This document describes the security measures required by GDPR Art. 32 (1). Based on our ISO 27001 certification we operate a risk-based ISMS leading to extensive security measures and documentation. We don't replicate the entire documentation here but only the gist.
 
@@ -52,28 +49,27 @@ situation, we'd like to first outline the general situation that hosting in
 the Flying Circus puts you in:
 
 Order data processing
-  applies within the framework of the GDPR. We will implement a contract for
+
+: applies within the framework of the GDPR. We will implement a contract for
   data processing suitable to the GDPR with you.
 
 Duty to give information
-  People who are affected by processing of data have right to request
+
+: People who are affected by processing of data have right to request
   information about what data about them is being stored as well as about the
   processes how this data is being kept secure.
 
 Periodical check for compliance to regulations:
-  The client has the responsibility to routinely check that applicable regulations
+
+: The client has the responsibility to routinely check that applicable regulations
   are being conformed to by their contractor. Yearly checks appear to
   be sufficient even for highly sensitive data (e.g. medical records). The
   result needs to be documented in written form. The audit usually needs to be
   performed by a third party.
 
+## Confidentiality
 
-Confidentiality
----------------
-
-
-Admission control
-~~~~~~~~~~~~~~~~~
+### Admission control
 
 **Measures for admission control ensure that unauthorized persons cannot
 physically access the data processing equipment.**
@@ -81,26 +77,24 @@ physically access the data processing equipment.**
 The physical assets (servers, switches, hard drives, ...) are located in EU
 data centers operated by third parties. The ownership of the physical equipment
 is with the Flying Circus, or, in special cases by our customers
-[#customer-owned]_.
+[^customer-owned].
 
 For each data center used by us we require the following measures:
 
-* video surveillance (outside facilities, in-doors and rack corridors)
-* two-factor security for granting access (e.g. personal password and
+- video surveillance (outside facilities, in-doors and rack corridors)
+- two-factor security for granting access (e.g. personal password and
   transponder card) with logging
-* physical access must be documented
-* preferably 24 hour guard services with linked alarm system
-* separate physical security zones for general areas, data center
+- physical access must be documented
+- preferably 24 hour guard services with linked alarm system
+- separate physical security zones for general areas, data center
   infrastructure and customer-accessible areas
-* separately locked racks with the possibility to use custom locks and keys.
+- separately locked racks with the possibility to use custom locks and keys.
 
-We maintain a separate :ref:`data-centers`.
+We maintain a separate {ref}`data-centers`.
 
-Physical access to data processing equipment may be performed only by the Flying Circus' :ref:`administrators <administrators>`. Administrators may delegate physical access to other persons (e.g., data center staff).
+Physical access to data processing equipment may be performed only by the Flying Circus' {ref}`administrators <administrators>`. Administrators may delegate physical access to other persons (e.g., data center staff).
 
-
-Low-security locations
-++++++++++++++++++++++
+#### Low-security locations
 
 The Flying Circus operates one low-security zone called `development` (used
 for the development of the Flying Circus infrastructure).
@@ -110,16 +104,14 @@ as they are not sufficiently protected.
 
 Due to this limitations, the services in high-security locations are not allowed to depend on services provided in low-security locations.
 
+(entry-control)=
 
-.. _entry-control:
-
-Entry control
-~~~~~~~~~~~~~
+### Entry control
 
 **Measures for entry control ensure that unauthorized third parties can not make use
 of the data processing systems.**
 
-.. ISMSControl: A.9.4.2
+% ISMSControl: A.9.4.2
 
 Machines managed within the Flying Circus can be accessed by a variety of ways for
 management purposes: SSH, web interfaces, and others. For those we employ
@@ -138,31 +130,31 @@ password, depending on the applicability.
 Users with a Flying Circus account are required to manage their password securely: Passwords must not become compromised if a device is being accessed unauthorizedly (logically or physically). Things to consider are for example: Home directory on a notebook, keychain or password manager software, backups, USB sticks, smartphones. Strongly encrypted storage of passwords is permitted and even advised. For Flying Circus staff there is a separate *guideline for handling secret authentication information*.
 
 All hardware machines have emergency root logins which may only be used by
-:ref:`Flying Circus administrators <administrators>` if regular user
+{ref}`Flying Circus administrators <administrators>` if regular user
 authentication is not working correctly. Such uses are monitored and must be documented.
 
 All privileged actions need to be securely logged. For machines based on our current (NixOS) platform, this is achieved via a local logging journal, which cannot be tampered with by normal users. Additionally systems logs are shipped to a central log server within the same site where the logs are analysed and monitored.
 
-SSH logins must be performed using SSH keys. Password authentication is not allowed and prevented by the system configuration. Successful SSH logins to machines are logged, unsuccessful SSH login attempts are not [#log-unsuccessful-attempts]_. Excessive unsuccessful SSH login attempts automatically cause a blocking via firewall rules.
+SSH logins must be performed using SSH keys. Password authentication is not allowed and prevented by the system configuration. Successful SSH logins to machines are logged, unsuccessful SSH login attempts are not [^log-unsuccessful-attempts]. Excessive unsuccessful SSH login attempts automatically cause a blocking via firewall rules.
 
+(access-control)=
 
-.. _access-control:
+### Access control
 
-Access control
-~~~~~~~~~~~~~~
-
-.. ISMSControl: A.9.1.1
+% ISMSControl: A.9.1.1
 
 **Measures for access control protect against access by unauthorized
 personnel.**
 
-Customer-owned virtual machines may be accessed by all Flying Circus :ref:`administrators <administrators>` implicitly. In projects additional staff (e.g. support staff) may get explicit access. Access by others (e.g., customer personnel, third parties) must be authorised by a client representative.
+Customer-owned virtual machines may be accessed by all Flying Circus {ref}`administrators <administrators>` implicitly. In projects additional staff (e.g. support staff) may get explicit access. Access by others (e.g., customer personnel, third parties) must be authorised by a client representative.
 
-.. ISMSControl: A.9.2.1
-.. ISMSControl: A.9.2.2
-.. ISMSControl: A.9.2.6
+% ISMSControl: A.9.2.1
 
-Users are centrally managed using https://my.flyingcircus.io. Users are automatically provisioned to all relevant systems, including proper removal of access rights.
+% ISMSControl: A.9.2.2
+
+% ISMSControl: A.9.2.6
+
+Users are centrally managed using <https://my.flyingcircus.io>. Users are automatically provisioned to all relevant systems, including proper removal of access rights.
 
 Flying Circus implements a permission-based concept to separate application
 maintenance tasks from privileged administrative tasks: for example, customer
@@ -172,24 +164,22 @@ Privileged administrative access is generally not granted to customers.
 In cases where another person who is not an
 administrator is needed to solve a problem, a shared session between an
 administrator and the other person must be established
-(e.g. with :command:`screen`).
+(e.g. with {command}`screen`).
 
 Technically, there are three access variants to perform privileged
 administrative operations:
 
-#. Using a user account which has been granted the 'login' and
-   'wheel' :ref:`permissions <permissions>` for a certain project. This
+1. Using a user account which has been granted the 'login' and
+   'wheel' {ref}`permissions <permissions>` for a certain project. This
    requires the user to log into a regular account using his SSH key and
    additionally provide his password to access privileged operations.
-
-#. Using a user account which is member of the global
-   group of administrators (see :ref:`administrators`) which grants access to
+2. Using a user account which is member of the global
+   group of administrators (see {ref}`administrators`) which grants access to
    all machines within the Flying Circus infrastructure.
-
-#. Emergency root logins (see above in :ref:`entry-control`).
+3. Emergency root logins (see above in {ref}`entry-control`).
 
 Authorized and unauthorized access to privileged operations is logged and analysed on a central loghost within the same site.
-[#trace-tty]_
+[^trace-tty]
 
 Flying Circus maintains a set of permissions which enable users to perform
 application maintenance and other semi-privileged tasks, e.g. access to
@@ -207,9 +197,7 @@ operations to ensure traceability of actions.
 Passwords for physical machines granting access to root accounts and IPMI
 controllers are stored as copies in a strongly encrypted password manager.
 
-
-Separation
-~~~~~~~~~~
+### Separation
 
 **Measures for separation ensure that data that is collected for separate
 purposes must be processed separately.**
@@ -223,34 +211,29 @@ standard UNIX permissions.
 Machines (both virtual and physical) live in a specific *access ring* (short:
 ring):
 
-* *Ring 0* machines perform infrastructure tasks. Thus, they need to process
+- *Ring 0* machines perform infrastructure tasks. Thus, they need to process
   data belonging to several customers.  Only administrator access is allowed on
   such machines.  Examples include VM hosts and storage servers.
-* *Ring 1* machines process data for a specific customer and are accessible to
+- *Ring 1* machines process data for a specific customer and are accessible to
   users associated to that customer. Examples include customer VMs.
 
 All resources that belong logically together (e.g., VMs, storage
 volumes) are bundled into *resource groups*. Resource groups share that same set
 of user accounts and permissions.
 
-
-Pseudonymisation
-~~~~~~~~~~~~~~~~
+### Pseudonymisation
 
 **Measures to ensure that personal data can no longer be attributed to a specific person without the use of additional information.**
 
-* We delete data after the retention times required by tax or commercial law.
-* Access log files are being anonymised.
-* We delete customer data upon customer's request.
+- We delete data after the retention times required by tax or commercial law.
+- Access log files are being anonymised.
+- We delete customer data upon customer's request.
 
+## Integrity and Authenticity
 
-Integrity and Authenticity
---------------------------
+### Transfer control
 
-Transfer control
-~~~~~~~~~~~~~~~~
-
-.. ISMSControl: A.14.1.2
+% ISMSControl: A.14.1.2
 
 **Measures for transfer control ensure that data that is being saved or
 transferred is protected against unauthorized reading, copying, modification, or
@@ -261,27 +244,22 @@ All private data transferred past the boundary of a machine must use an
 authenticated and encrypted communication channel (exceptions see below).
 Data paths where sensitive information may be transferred include:
 
-* Application data (e.g., database contents) is transferred from or to the
+- Application data (e.g., database contents) is transferred from or to the
   customer using the standardised encrypted protocols, e.g., SCP/SFTP, https.
-
-* Persistent data is saved on storage servers. Storage traffic is not encrypted
+- Persistent data is saved on storage servers. Storage traffic is not encrypted
   due to performance reasons. Storage servers are connected to application
   servers using a private network. Machines on which administrative privileges
   are granted to customers are not allowed to connect directly to the storage
-  network (see also :ref:`network-security`).
-
-* Backups are transferred to backup servers at the same site using either an encrypted
+  network (see also {ref}`network-security`).
+- Backups are transferred to backup servers at the same site using either an encrypted
   communication channel or the private storage network. Backup data may also be
   transferred to off-site backup servers to improve disaster recovery abilities. The transfer must be encrypted.
-
-* In addition to application data, a system can generate data at runtime that
+- In addition to application data, a system can generate data at runtime that
   contains sensitive information, for example log files. Log files usually do
   not leave the machine on which they were generated, unless the customer operates a logging server. Log data may also be transferred to a log server on the same site operated by Flying Circus via an encrypted channel. Only Flying Circus
   administrators may have access to the central log server.
 
-
-Input control
-~~~~~~~~~~~~~
+### Input control
 
 **Measures for input control ensure that input, change, and deletion of data are
 documented showing at least who worked when on what data.**
@@ -305,9 +283,7 @@ the customer themselves or through our support. If the change happens through
 our support then it must be documented beforehand and confirmed by the customer
 after the change has been performed.
 
-
-Order control
-~~~~~~~~~~~~~
+### Order control
 
 **Measures for order control ensure that data is only processed according to the
 orders of the client.**
@@ -321,9 +297,7 @@ request tracking system. Other means of documentation to control changes are pos
 
 Specific actions performed will be reported to the customer if required.
 
-
-Availability
-------------
+## Availability
 
 **Measures for availability ensure that data is not accidentally destroyed or
 lost.**
@@ -338,36 +312,33 @@ increased availability of single components (e.g., RAID storages, redundant
 power supplies, spare components).
 
 Customer data is regularly backed up according to the Flying Circus'
-:ref:`backup schedule <backup>`. Restoration of past states may be performed
+{ref}`backup schedule <backup>`. Restoration of past states may be performed
 by administrators on request. Additionally, a
-:ref:`disaster recovery plan <disaster-recovery>` details failure scenarios,
+{ref}`disaster recovery plan <disaster-recovery>` details failure scenarios,
 our preventative and recovery measures.
 
+## Other measures
 
+- Our support process and incident response measures are documented at {ref}`the support overview <support-details>`.
+- We have a process for emergency and crisis management including contingency plans for critical business processes (business continuity). See also {ref}`disaster-recovery`.
 
-Other measures
---------------
+```{rubric} Footnotes
+```
 
-* Our support process and incident response measures are documented at :ref:`the support overview <support-details>`.
-* We have a process for emergency and crisis management including contingency plans for critical business processes (business continuity). See also :ref:`disaster-recovery`.
-
-
-.. rubric:: Footnotes
-
-.. [#customer-owned] If a customer owns equipment managed within the Flying Circus we
+[^customer-owned]: If a customer owns equipment managed within the Flying Circus we
     require that this customer uses a separate rack with separate access control.
 
-.. [#log-unsuccessful-attempts] We consider not logging unsuccessful logins
-   acceptable, as SSH logins are only valid using cryptographic private/public
-   key authentication. Password logins are always rejected. Potential attack
-   vectors are thus limited to stolen or cracked private keys or vulnerabilities
-   in the SSH server software. Cracked keys are practically impossible using
-   current technology. Known broken key formats are revoked/rejected regularly.
-   Stolen keys or errors in the server software will not be
-   traceable using unsuccessful login records either.  On the opposite: the
-   amount of password login tries performed nowadays (due to bot nets etc.)
-   would cause spamming of the logging infrastructure which in turn can be a
-   vector for DOS attacks.
+[^log-unsuccessful-attempts]: We consider not logging unsuccessful logins
+    acceptable, as SSH logins are only valid using cryptographic private/public
+    key authentication. Password logins are always rejected. Potential attack
+    vectors are thus limited to stolen or cracked private keys or vulnerabilities
+    in the SSH server software. Cracked keys are practically impossible using
+    current technology. Known broken key formats are revoked/rejected regularly.
+    Stolen keys or errors in the server software will not be
+    traceable using unsuccessful login records either.  On the opposite: the
+    amount of password login tries performed nowadays (due to bot nets etc.)
+    would cause spamming of the logging infrastructure which in turn can be a
+    vector for DOS attacks.
 
-.. [#trace-tty] Individual actions performed with administrative privileges are
-   only partially logged.
+[^trace-tty]: Individual actions performed with administrative privileges are
+    only partially logged.

--- a/src/reference/security/data-protection.md
+++ b/src/reference/security/data-protection.md
@@ -137,6 +137,24 @@ All privileged actions need to be securely logged. For machines based on our cur
 
 SSH logins must be performed using SSH keys. Password authentication is not allowed and prevented by the system configuration. Successful SSH logins to machines are logged, unsuccessful SSH login attempts are not [^log-unsuccessful-attempts]. Excessive unsuccessful SSH login attempts automatically cause a blocking via firewall rules.
 
+(data-at-rest-encryption)=
+
+### Data media control
+
+All data in our [storage clusters](#infrastructure-storage) is stored encrypted.
+This includes the *Virtual Disk Block Storage*, our *S3-compatible Object
+Storage*, and [all automated backups](#backup). There are technical and
+organisational measures in place to protect the relevant keys.
+
+On a technical level, we utilise the common Linux [cryptsetup]
+(https://gitlab.com/cryptsetup/cryptsetup) software stack with LUKS2 metadata
+and XTS-AES-512 cipher. We regularly review recommendations in standard
+guidelines or working groups and are able to update the used encryption
+parameters as needed.
+
+Disposal of used media happens using a certified data destruction service
+provider.
+
 (access-control)=
 
 ### Access control
@@ -197,15 +215,6 @@ operations to ensure traceability of actions.
 Passwords for physical machines granting access to root accounts and IPMI
 controllers are stored as copies in a strongly encrypted password manager.
 
-(data-at-rest-encryption)=
-
-### Data-at-Rest Encryption
-
-All data in our [storage cluster](#infrastructure-storage) is stored encrypted. This includes the *Virtual Disk Block Storage*, our *S3-compatible Object Storage*, and [all automated backups](#backup). Whenever storage media are located outside our trusted areas, we have technical and organisational measures in place to ensure the confidentiality of the data stored there.
-
-On a technical level, we utilise the common Linux [cryptsetup](https://gitlab.com/cryptsetup/cryptsetup) software stack with LUKS2 metadata and XTS-AES-512 cipher. We regularly review recommendations in standard guidelines or working groups and are able to update the used encryption parameters once necessary.
-
-On an organisational level, we have procedures in place that ensure the separation of storage medium and key material when disks leave trusted areas.
 
 ### Separation
 

--- a/src/reference/security/data-protection.md
+++ b/src/reference/security/data-protection.md
@@ -197,6 +197,16 @@ operations to ensure traceability of actions.
 Passwords for physical machines granting access to root accounts and IPMI
 controllers are stored as copies in a strongly encrypted password manager.
 
+(data-at-rest-encryption)=
+
+### Data-at-Rest Encryption
+
+All data in our [storage cluster](#infrastructure-storage) is stored encrypted. This includes the *Virtual Disk Block Storage*, our *S3-compatible Object Storage*, and [all automated backups](#backup). Whenever storage media are located outside our trusted areas, we have technical and organisational measures in place to ensure the confidentiality of the data stored there.
+
+On a technical level, we utilise the common Linux [cryptsetup](https://gitlab.com/cryptsetup/cryptsetup) software stack with LUKS2 metadata and XTS-AES-512 cipher. We regularly review recommendations in standard guidelines or working groups and are able to update the used encryption parameters once necessary.
+
+On an organisational level, we have procedures in place that ensure the separation of storage medium and key material when disks leave trusted areas.
+
 ### Separation
 
 **Measures for separation ensure that data that is collected for separate


### PR DESCRIPTION
This updates our public documentation to reflect the successful rollout of PL-131325 with the deploayment of disk encryption in our storage.

Changes to out data protection reference require special caution and need to be reviewed by @zagy or @ctheune. Until then, keeping this as draft.