### PR TITLE
[FC-40718] docs/mongodb: update usage instructions

### DIFF
--- a/src/guide/deployment/mongodb.md
+++ b/src/guide/deployment/mongodb.md
@@ -84,7 +84,7 @@ in {
     preStart = "echo never > /sys/kernel/mm/transparent_hugepage/defrag";
     postStop = "echo always > /sys/kernel/mm/transparent_hugepage/defrag";
     # intial creating of journal takes ages
-    serviceConfig.TimeoutStartSec = 1200;
+    serviceConfig.TimeoutStartSec = lib.mkForce 1200;
     serviceConfig.LimitNOFILE = 64000;
     serviceConfig.LimitNPROC = 32000;
     serviceConfig.Restart = "always";
@@ -102,6 +102,9 @@ in {
     shell = "/run/current-system/sw/bin/bash";
     home = "/srv/mongodb";
   };
+
+  # Only needed when using `pkgs.mongodb-X_Y`
+  flyingcircus.allowedUnfreePackageNames = [ "mongodb" ];
 
   flyingcircus.infrastructure.preferNoneSchedulerOnSsd = true;
 


### PR DESCRIPTION


The issue is actually about a SIGILL on startup, but this was already fixed upstream[1], so need to update our docs on that end.

While debugging, I however noticed a few other problems, namely:

* TimeoutStartSec is set in the upstream module, so we have to `mkForce` it here.

* When using a package from nixpkgs, we have to allow it since it's unfree.

[1] https://github.com/NixOS/nixpkgs/commit/2e9c2a5c3c6ac2b3af8091fefcc8827b539cad20