### PR TITLE
Correct deletion time period for VMs (DIR-741)

### DIFF
--- a/src/infrastructure/vms/index.md
+++ b/src/infrastructure/vms/index.md
@@ -93,7 +93,7 @@ Hard
 
 Purge
 
-: (t+8 days)
+: (t+32 days)
 
   Delete the VMs backups.
 


### PR DESCRIPTION
In DIR-741 we changed the deletion schedule so that VM backups get deleted at T+32 days.